### PR TITLE
Add version in tool

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,17 +22,21 @@ jobs:
       - name: Set up build output directory
         run: mkdir -p dist
 
+      - name: Get version from tag
+        id: get_version
+        run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
+
       - name: Build for Linux amd64
         run: |
-          GOOS=linux GOARCH=amd64 go build -o dist/oidc-helper-linux-amd64
+          GOOS=linux GOARCH=amd64 go build -ldflags "-X main.Version=${VERSION}" -o dist/oidc-helper-linux-amd64
 
       - name: Build for Windows amd64
         run: |
-          GOOS=windows GOARCH=amd64 go build -o dist/oidc-helper-windows-amd64.exe
+          GOOS=windows GOARCH=amd64 go build -ldflags "-X main.Version=${VERSION}" -o dist/oidc-helper-windows-amd64.exe
 
       - name: Build for macOS amd64
         run: |
-          GOOS=darwin GOARCH=amd64 go build -o dist/oidc-helper-darwin-amd64
+          GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.Version=${VERSION}" -o dist/oidc-helper-darwin-amd64
 
       - name: Upload release assets
         uses: softprops/action-gh-release@v2
@@ -43,4 +47,3 @@ jobs:
             dist/oidc-helper-darwin-amd64
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-

--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ providers:
 - `--daemon`: Run as a daemon to hold the token in memory (internal use only).
 - `--pipe <name>`: Named pipe/socket name for daemon communication (default: oidc-helper-pipe).
 - `--log <level>`: Set log level (`debug`, `info`, `warn`, `error`; default: `warn`).
+- `--version`: Show the current version of the tool and exit.
 - `--help`, `-h`: Show all available options and usage information.
 
 For help and available options, run:
@@ -92,6 +93,11 @@ For help and available options, run:
 - **Show all available options:**
   ```sh
   ./oidc-helper --help
+  ```
+
+- **Show the current version:**
+  ```sh
+  ./oidc-helper --version
   ```
 
 ---

--- a/main.go
+++ b/main.go
@@ -17,6 +17,8 @@ import (
 	"time"
 )
 
+var Version = "dev"
+
 func openBrowser(url string) {
 	var cmd string
 	var args []string
@@ -35,6 +37,7 @@ func openBrowser(url string) {
 }
 
 func main() {
+	versionFlag := flag.Bool("version", false, "show version and exit")
 	daemon := flag.Bool("daemon", false, "run as daemon to hold token in memory")
 	pipeName := flag.String("pipe", "oidc-helper-pipe", "named pipe/socket name for daemon communication")
 	help := flag.Bool("help", false, "display help and exit")
@@ -45,10 +48,16 @@ func main() {
 	logutil.LogLevel = logutil.ParseLogLevel(*logFlag)
 
 	flag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "oidc-helper version: %s\n", Version)
 		fmt.Fprintf(os.Stderr, "Usage: %s [options]\n", os.Args[0])
 		flag.PrintDefaults()
 	}
 	flag.Parse()
+
+	if *versionFlag {
+		fmt.Println(Version)
+		os.Exit(0)
+	}
 
 	if *help || *h {
 		flag.Usage()


### PR DESCRIPTION
This pull request introduces versioning support for the `oidc-helper` tool, along with updates to the build process, documentation, and CLI functionality. The most important changes include embedding version information during builds, adding a `--version` flag to display the version, and updating the documentation to reflect these changes.
