### PR TITLE
Feat/list providers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,10 @@ jobs:
         run: |
           GOOS=darwin GOARCH=amd64 go build -ldflags "-X main.Version=${VERSION}" -o dist/oidc-helper-darwin-amd64
 
+      - name: Build for macOS arm64 (Apple Silicon)
+        run: |
+          GOOS=darwin GOARCH=arm64 go build -ldflags "-X main.Version=${VERSION}" -o dist/oidc-helper-darwin-arm64
+
       - name: Upload release assets
         uses: softprops/action-gh-release@v2
         with:
@@ -45,5 +49,6 @@ jobs:
             dist/oidc-helper-linux-amd64
             dist/oidc-helper-windows-amd64.exe
             dist/oidc-helper-darwin-amd64
+            dist/oidc-helper-darwin-arm64
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /oidc-helper
+/dist/

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ providers:
 
 **Common options:**
 - `--provider <name>`: Use a specific provider from your config file (overrides default).
+- `--list-providers`: List all available OIDC providers from your config file. The default provider is marked with an asterisk (`*`).
 - `--daemon`: Run as a daemon to hold the token in memory (internal use only).
 - `--pipe <name>`: Named pipe/socket name for daemon communication (default: oidc-helper-pipe).
 - `--log <level>`: Set log level (`debug`, `info`, `warn`, `error`; default: `warn`).
@@ -117,6 +118,15 @@ For help and available options, run:
       }
     }
   }
+  ```
+
+- **List all available providers (default marked with *):**
+  ```sh
+  ./oidc-helper --list-providers
+  # Output example:
+  # Available providers:
+  # - provider1 *
+  # - provider2
   ```
 
 - **Show all available options:**

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ func main() {
 	h := flag.Bool("h", false, "display help and exit (shorthand)")
 	logFlag := flag.String("log", "warn", "set log level: debug, info, warn, error")
 	providerName := flag.String("provider", "", "OIDC provider name (overrides default)")
+	listProviders := flag.Bool("list-providers", false, "list available OIDC providers and exit")
 
 	logutil.LogLevel = logutil.ParseLogLevel(*logFlag)
 
@@ -53,6 +54,23 @@ func main() {
 		flag.PrintDefaults()
 	}
 	flag.Parse()
+
+	if *listProviders {
+		cfg, err := config.LoadConfig()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error loading config: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Println("Available providers:")
+		for name := range cfg.Providers {
+			if name == cfg.Default {
+				fmt.Println("-", name, "*")
+			} else {
+				fmt.Println("-", name)
+			}
+		}
+		os.Exit(0)
+	}
 
 	if *versionFlag {
 		fmt.Println(Version)


### PR DESCRIPTION
This pull request introduces support for macOS arm64 builds and adds a new feature to list all available OIDC providers from the configuration. The most important changes are grouped into build enhancements and feature additions.

### Build Enhancements:
* Added a new build step in `.github/workflows/release.yml` to compile the binary for macOS arm64 (Apple Silicon) and updated the release assets to include the `oidc-helper-darwin-arm64` binary.

### Feature Additions:
* Introduced a `--list-providers` flag in `main.go` to display all available OIDC providers from the configuration file, marking the default provider with an asterisk (`*`). [[1]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R47) [[2]](diffhunk://#diff-2873f79a86c0d8b3335cd7731b0ecf7dd4301eb19a82ef7a1cba7589b5252261R58-R74)
* Updated `README.md` to document the `--list-providers` flag and provide an example of its usage. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R68) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R123-R131)