### PR TITLE
feat: add Homebrew installation support

### DIFF
--- a/.github/workflows/homebrew-formula-update.yml
+++ b/.github/workflows/homebrew-formula-update.yml
@@ -1,0 +1,127 @@
+name: Homebrew Formula Update
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to update (e.g., v0.1.0)'
+        required: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-formula:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+
+      - name: Get version
+        id: version
+        run: |
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            VERSION="${{ github.event.release.tag_name }}"
+          fi
+          echo "version=${VERSION#v}" >> $GITHUB_OUTPUT
+
+      - name: Download and verify release binaries
+        id: sha256
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          declare -A shas
+          for arch in amd64 arm64; do
+            for os in darwin linux; do
+              url="https://github.com/GregoireW/oidc-helper/releases/download/v${VERSION}/oidc-helper_${VERSION}_${os}_${arch}.tar.gz"
+              echo "Downloading $url..."
+              curl -sL "$url" -o /tmp/archive.tar.gz
+              sha=$(sha256sum /tmp/archive.tar.gz | cut -d' ' -f1)
+              key="${os}_${arch}"
+              echo "${key}=${sha}" >> $GITHUB_OUTPUT
+              rm -f /tmp/archive.tar.gz
+            done
+          done
+
+      - name: Update Homebrew formula
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          SHA_DARWIN_AMD64: ${{ steps.sha256.outputs.darwin_amd64 }}
+          SHA_DARWIN_ARM64: ${{ steps.sha256.outputs.darwin_arm64 }}
+          SHA_LINUX_AMD64: ${{ steps.sha256.outputs.linux_amd64 }}
+          SHA_LINUX_ARM64: ${{ steps.sha256.outputs.linux_arm64 }}
+        run: |
+          cat > Formula/oidc-helper.rb << EOF
+          class OidcHelper < Formula
+            desc "OIDC Helper - Lightweight CLI tool to simplify OIDC authentication flows"
+            homepage "https://github.com/GregoireW/oidc-helper"
+            license "Apache-2.0"
+            version "$VERSION"
+            on_macos do
+              on_arm do
+                url "https://github.com/GregoireW/oidc-helper/releases/download/v${VERSION}/oidc-helper_${VERSION}_darwin_arm64.tar.gz"
+                sha256 "${SHA_DARWIN_ARM64}"
+              end
+              on_intel do
+                url "https://github.com/GregoireW/oidc-helper/releases/download/v${VERSION}/oidc-helper_${VERSION}_darwin_amd64.tar.gz"
+                sha256 "${SHA_DARWIN_AMD64}"
+              end
+            end
+            on_linux do
+              on_arm do
+                url "https://github.com/GregoireW/oidc-helper/releases/download/v${VERSION}/oidc-helper_${VERSION}_linux_arm64.tar.gz"
+                sha256 "${SHA_LINUX_ARM64}"
+              end
+              on_intel do
+                url "https://github.com/GregoireW/oidc-helper/releases/download/v${VERSION}/oidc-helper_${VERSION}_linux_amd64.tar.gz"
+                sha256 "${SHA_LINUX_AMD64}"
+              end
+            end
+            def install
+              bin.install "oidc-helper"
+            end
+            test do
+              system "#{bin}/oidc-helper", "--version"
+            end
+          end
+          EOF
+          echo "Formula updated successfully"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          base: main
+          commit-message: "chore(homebrew): update formula to v${{ steps.version.outputs.version }}"
+          title: "chore(homebrew): update formula to v${{ steps.version.outputs.version }}"
+          body: |
+            ## Summary
+            This PR updates the Homebrew formula to version **${{ steps.version.outputs.version }}**.
+
+            ### Changes
+            - Updated SHA256 checksums for all platform binaries:
+              - darwin/amd64
+              - darwin/arm64
+              - linux/amd64
+              - linux/arm64
+
+            ### Verification
+            The formula is now ready for Homebrew installation:
+            ```bash
+            brew tap GregoireW/oidc-helper https://github.com/GregoireW/oidc-helper
+            brew install oidc-helper
+            ```
+
+            Created by GitHub Actions - [Homebrew Formula Update](https://github.com/GregoireW/oidc-helper/actions/workflows/homebrew-formula-update.yml)
+          branch: homebrew-formula-update-v${{ steps.version.outputs.version }}
+          delete-branch: true
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,10 @@ jobs:
         run: |
           GOOS=linux GOARCH=amd64 go build -ldflags "-X main.Version=${VERSION}" -o dist/oidc-helper-linux-amd64
 
+      - name: Build for Linux arm64
+        run: |
+          GOOS=linux GOARCH=arm64 go build -ldflags "-X main.Version=${VERSION}" -o dist/oidc-helper-linux-arm64
+
       - name: Build for Windows amd64
         run: |
           GOOS=windows GOARCH=amd64 go build -ldflags "-X main.Version=${VERSION}" -o dist/oidc-helper-windows-amd64.exe
@@ -42,13 +46,27 @@ jobs:
         run: |
           GOOS=darwin GOARCH=arm64 go build -ldflags "-X main.Version=${VERSION}" -o dist/oidc-helper-darwin-arm64
 
+      - name: Create Homebrew archives
+        run: |
+          cd dist
+          for src in oidc-helper-darwin-amd64 oidc-helper-darwin-arm64 oidc-helper-linux-amd64 oidc-helper-linux-arm64; do
+            os_arch="${src#oidc-helper-}"
+            os="${os_arch%-*}"
+            arch="${os_arch##*-}"
+            mkdir -p "archive/${os_arch}"
+            cp "${src}" "archive/${os_arch}/oidc-helper"
+            tar czf "oidc-helper_${VERSION}_${os}_${arch}.tar.gz" -C "archive/${os_arch}" oidc-helper
+          done
+
       - name: Upload release assets
         uses: softprops/action-gh-release@v2
         with:
           files: |
             dist/oidc-helper-linux-amd64
+            dist/oidc-helper-linux-arm64
             dist/oidc-helper-windows-amd64.exe
             dist/oidc-helper-darwin-amd64
             dist/oidc-helper-darwin-arm64
+            dist/oidc-helper_*.tar.gz
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Formula/oidc-helper.rb
+++ b/Formula/oidc-helper.rb
@@ -1,0 +1,37 @@
+class OidcHelper < Formula
+  desc "OIDC Helper - Lightweight CLI tool to simplify OIDC authentication flows"
+  homepage "https://github.com/GregoireW/oidc-helper"
+  license "Apache-2.0"
+
+  version "0.1.0"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/GregoireW/oidc-helper/releases/download/v0.1.0/oidc-helper_0.1.0_darwin_arm64.tar.gz"
+      sha256 "PLACEHOLDER"
+    end
+    on_intel do
+      url "https://github.com/GregoireW/oidc-helper/releases/download/v0.1.0/oidc-helper_0.1.0_darwin_amd64.tar.gz"
+      sha256 "PLACEHOLDER"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/GregoireW/oidc-helper/releases/download/v0.1.0/oidc-helper_0.1.0_linux_arm64.tar.gz"
+      sha256 "PLACEHOLDER"
+    end
+    on_intel do
+      url "https://github.com/GregoireW/oidc-helper/releases/download/v0.1.0/oidc-helper_0.1.0_linux_amd64.tar.gz"
+      sha256 "PLACEHOLDER"
+    end
+  end
+
+  def install
+    bin.install "oidc-helper"
+  end
+
+  test do
+    system "#{bin}/oidc-helper", "--version"
+  end
+end

--- a/README.md
+++ b/README.md
@@ -6,9 +6,18 @@ A simple command-line tool to help you authenticate with OpenID Connect (OIDC) p
 
 ## 🚀 Quick Start
 
+### macOS (Homebrew)
+
+```bash
+brew tap GregoireW/oidc-helper https://github.com/GregoireW/oidc-helper
+brew install oidc-helper
+```
+
+### Linux / Windows
+
 1. **Download the Latest Release:**
    - Visit the [Releases page](https://github.com/GregoireW/oidc-helper/releases) and download the latest version for your operating system.
-   - Extract the archive and place the `oidc-helper` executable somewhere in your `PATH` (e.g., `/usr/local/bin` on Linux/macOS).
+   - Extract the archive and place the `oidc-helper` executable somewhere in your `PATH` (e.g., `/usr/local/bin` on Linux).
 
 2. **Configure the Tool:**
    - Create a configuration file named `config.yaml` (see below for details).


### PR DESCRIPTION
## Summary

This PR adds Homebrew support for macOS (and Linux via Homebrew on Linux), following the same in-repo tap pattern used by [leanproxy-mcp](https://github.com/mmornati/leanproxy-mcp).

## Changes

### 1. Homebrew formula (`Formula/oidc-helper.rb`)
- In-repo tap formula for Homebrew
- Supports 4 platform bottles: darwin/amd64, darwin/arm64, linux/amd64, linux/arm64
- Installs the `oidc-helper` binary into Homebrew's bin directory
- Runs `oidc-helper --version` as install verification test

### 2. Homebrew formula auto-update workflow (`.github/workflows/homebrew-formula-update.yml`)
- Triggers on every published GitHub Release (and supports manual dispatch)
- Downloads the 4 platform `.tar.gz` archives from the release
- Computes SHA256 checksums for each archive
- Regenerates `Formula/oidc-helper.rb` with the correct version, URLs, and checksums
- Opens a PR against `main` with the updated formula

### 3. Updated release workflow (`.github/workflows/release.yml`)
- Added linux/arm64 build target (was missing)
- Added a step to create `.tar.gz` archives for all 4 Homebrew platforms
- Archives are uploaded alongside the existing raw binaries

### 4. Updated README
- Added macOS Homebrew install instructions (`brew tap` + `brew install`)
- Linux/Windows manual download instructions moved under a subsection

## How it works

1. Push a tag `v1.0.0` → release workflow builds binaries + creates `.tar.gz` archives, uploads to GitHub Release
2. Release gets published → formula update workflow computes checksums, updates `Formula/oidc-helper.rb`, opens a PR
3. Merge the PR → users can install via:

```bash
brew tap GregoireW/oidc-helper https://github.com/GregoireW/oidc-helper
brew install oidc-helper
```